### PR TITLE
Fix osticket cronjob

### DIFF
--- a/install/assets/cron/crontab.txt
+++ b/install/assets/cron/crontab.txt
@@ -1,1 +1,1 @@
-*/<CRON_PERIOD> * * * * php -q -d /www/osticket/upload/api/cron.php >/dev/null 2>&1
+*/<CRON_PERIOD> * * * * php -q /www/osticket/upload/api/cron.php >/dev/null 2>&1


### PR DESCRIPTION
I spent a while debugging why our cronjob wouldn't run. Turns out it was the `-d` option.

```
$ php --help
[…]
-d foo[=bar]     Define INI entry foo with value 'bar'
```

I don't know what `-d` was _supposed_ to do here but it seems like it causes the file path to be defined as an INI entry and no file to be executed. Thus php uses the script from stdin, which is nothing, and does nothing.

This fixes it and now we get tickets created even when we're not active in osTicket (i.e. triggering the auto-cron).