### PR TITLE
Cleanup alpine -> debian, also clean composer cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,11 @@ RUN set -x && \
     chown nginx:www-data /var/log/msmtp.log && \
    \
 ## Cleanup
-    rm -rf /var/cache/apk/* /tmp/* && \
-    rm -rf /usr/src/*
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/* && \
+    rm -rf /usr/src/* && \
+    rm -rf /root/.composer/cache
 
 ### Add Files
 ADD install /


### PR DESCRIPTION
Cleanup Debian's package lists and cache instead of Alpine's.  Also removes the composer cache, which cuts the size of the new layer approximately in half.