### PR TITLE
Fix cron.php not running due to incorrect path

### DIFF
--- a/install/assets/cron/osticket.txt
+++ b/install/assets/cron/osticket.txt
@@ -1,1 +1,1 @@
-*/<CRON_PERIOD> * * * * TZ=${TIMEZONE} php -q /www/${NGINX_WEBROOT}/api/cron.php >/dev/null 2>&1
+*/<CRON_PERIOD> * * * * TZ=${TIMEZONE} php -q ${NGINX_WEBROOT}/api/cron.php >/dev/null 2>&1


### PR DESCRIPTION
`NGINX_WEBROOT` is `/www/osticket` by default, so the path in crontab was expanding to `/www//www/osticket/api/cron.php` which doesn't exist.  This PR fixes the path in the crontab.