### PR TITLE
Changed the docker-compose db-backup image

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -63,7 +63,7 @@ services:
 
   osticket-db-backup:
     container_name: osticket-db-backup
-    image: tiredofit/mariadb-backup
+    image: tiredofit/db-backup
     links:
       - osticket-db
     volumes:


### PR DESCRIPTION
Changed the docker-compose example file to correct the issue with mariadb-backup changing to db-backup. This corrects #14 issue listed by ninjamonkey198206.