### PR TITLE
fix(install): Fixed command to count letters admin username

### DIFF
--- a/install/etc/cont-init.d/30-osticket
+++ b/install/etc/cont-init.d/30-osticket
@@ -12,7 +12,7 @@ sanity_var ADMIN_PASS "Admin Password"
 sanity_var ADMIN_EMAIL "Admin Email"
 sanity_var ADMIN_USER "Admin Username"
 
-if [ "$(wc -c "${ADMIN_USER}")" -le 5 ] ; then
+if [ "$(echo "${ADMIN_USER}" | wc -c)" -le 5 ] ; then
     print_error "Admin user need to be 5 characters or greater. Exiting.."
     exit 5
 fi


### PR DESCRIPTION
This PR fixes the second part of the bug #33 described [here](https://github.com/tiredofit/docker-osticket/issues/33#issuecomment-1566021067)