### PR TITLE
chore(install): Show PHP install script logs to help debug installation failures

### DIFF
--- a/install/etc/cont-init.d/30-osticket
+++ b/install/etc/cont-init.d/30-osticket
@@ -43,7 +43,7 @@ if [ ! -f "${NGINX_WEBROOT}"/index.php ] ; then
 fi
 
 # Automate installation
-silent php /assets/setup/install.php
+php /assets/setup/install.php
 
 ## Check Memcache Settings
 if [ -n "${MEMCACHE_HOST}" ]; then


### PR DESCRIPTION
This will add installation logs from the `install.php` script.

When everything is fine, it looks like this:
```
** [osticket] Configuring mail settings
** [osticket] DB - Connecting to database mysql://osticket@host.docker.internal/osticket
** [osticket] DB - Using installation secret from INSTALL_SECRET environmental variable
** [osticket] DB - Updating configuration file
** [osticket] DB - Installing database. Please wait...
** [osticket] DB - Database installation successful
```

When something goes wrong, it helps fix it. For example:
```
** [osticket] Configuring mail settings
** [osticket] DB - Connecting to database mysql://osticket@host.docker.internal/osticket
** [osticket] DB - Using installation secret from INSTALL_SECRET environmental variable
** [osticket] DB - Updating configuration file
** [osticket] DB - Installing database. Please wait...
** [osticket] DB - Database installation failed. Errors:
  Conflicts with system email above
```